### PR TITLE
Add kiosk Docker setup and scripts

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,0 +1,16 @@
+# Balena Chromium kiosk for Raspberry Pi 400
+FROM balenalib/rpi-raspbian:bullseye
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        chromium-browser \
+        matchbox-window-manager \
+        xserver-xorg && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV BROWSER_URL=http://192.168.50.10
+
+COPY start.sh /usr/src/app/start.sh
+RUN chmod +x /usr/src/app/start.sh
+
+CMD ["/usr/src/app/start.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Chromium launch flags in `start.sh`:
 
 ### Network & IP
 - Assign a static IP (`192.168.50.10`) via DHCP reservation or `/etc/dhcpcd.conf`.
+- Example `/etc/dhcpcd.conf` snippet:
+```
+interface eth0
+static ip_address=192.168.50.10/24
+static routers=192.168.50.1
+static domain_name_servers=192.168.50.1
+```
+- For Wi-Fi, set `BALENA_WIFI_SSID` and `BALENA_WIFI_KEY` in Balena Cloud.
 - Ensure the Pi 400 joins the correct network on boot.
 
 ## Build & Deployment
@@ -116,4 +124,4 @@ Confirm Chromium starts and navigates to the target URL.
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the MIT License. See [LICENSE](LICENSE).

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "browserUrl": "http://192.168.50.10",
+  "chromiumFlags": ["--kiosk", "--no-first-run", "--disable-infobars"]
+}

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+URL="${BROWSER_URL:-http://192.168.50.10}"
+
+# Wait for X to be ready
+if [ -x /usr/bin/startx ]; then
+    startx /usr/bin/chromium-browser -- \
+        --kiosk "$URL" \
+        --no-first-run \
+        --disable-infobars \
+        --disable-session-crashed-bubble
+else
+    chromium-browser --kiosk "$URL" \
+        --no-first-run \
+        --disable-infobars \
+        --disable-session-crashed-bubble
+fi


### PR DESCRIPTION
## Summary
- add Dockerfile and start script for Chromium kiosk
- include sample configuration file and MIT license
- expand network setup instructions in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686309dcbc7c832db93b6268cded9cdf