### PR TITLE
Add Chromium kiosk container

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,0 +1,17 @@
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:buster
+
+# Default page to load
+ENV BROWSER_URL="http://192.168.50.10" \
+    DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
+
+RUN apt-get update && apt-get install -y \
+    chromium-browser \
+    matchbox-window-manager \
+    xinit \
+    x11-xserver-utils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY start.sh /usr/src/start.sh
+RUN chmod +x /usr/src/start.sh
+
+CMD ["/usr/src/start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,292 +1,38 @@
-1. Environment & Toolchain Setup
-Prepare hardware
+# Chromium Kiosk
 
-Raspberry Pi 400 with official power supply
+This project builds a small Balena container that runs Chromium in kiosk mode. It is
+intended for devices like the Raspberry Pi 4 or 400.
 
-microSD card (≥ 16 GB, Class 10)
+## Files
 
-HDMI cable + monitor
+- **Dockerfile.template** – installs Chromium and X11 utilities and sets up the
+  container entrypoint.
+- **start.sh** – entry script that launches Chromium and restarts it if it exits.
 
-Install and configure Balena tools
+## Configuration
 
-Install the Balena CLI on your development machine.
+Set the `BROWSER_URL` environment variable to change the page that loads on
+startup. If not provided, the script falls back to `http://192.168.50.10`.
 
-Create or sign in to your Balena Cloud account.
+## Usage
 
-Verify you can provision and SSH into a test device.
+1. Build the image locally or deploy with Balena Cloud.
 
-2. Repository Familiarization
-Clone the repo
-
-bash
-Copy
-Edit
-git clone https://github.com/balena-io-experimental/browser.git
-cd browser
-Review key files
-
-Dockerfile.template (service image and dependencies)
-
-start.sh (entrypoint that launches Chromium in kiosk mode)
-
-config.json or environment‐variable conventions (URL, flags)
-
-3. Kiosk Configuration
-Define your target URL
-
-Either bake it into the service’s ENV BROWSER_URL or expose it as a device ­environment variable in Balena Cloud.
-
-Chromium launch flags (in start.sh)
-
---kiosk
-
---no-first-run
-
---disable-infobars
-
---incognito (optional)
-
-Network & IP
-
-Assign a static IP (192.168.50.10) via DHCP reservation or in /etc/dhcpcd.conf in the container.
-
-Ensure the Pi400 joins the correct SSID or Ethernet network on boot.
-
-4. Build & Deployment
-Local build test
-
-Run balena local build --arch=arm64 . to verify the image builds.
-
-Push to Balena Cloud
-
-balena push <yourAppName>
-
-Provision your Pi400
-
-Download the Balena-flashed image and boot the device.
-
-Confirm it comes online in Balena Cloud.
-
-5. Validation & Troubleshooting
-Boot verification
-
-Watch device logs (balena logs <device-uuid>) to confirm Chromium starts and navigates to http://192.168.50.10.
-
-Performance tuning
-
-Enable GPU acceleration flags if needed (--use-gl=egl, --enable-features=VaapiVideoDecoder).
-
-Disable unneeded services to minimize boot time.
-
-Resilience
-
-Add a watchdog in start.sh to restart Chromium on crash.
-
-Persist cookies or localStorage only if required.
-
-6. Documentation & Handoff
-Update README.md
-
-Document all steps: flashing, environment variables, flags, troubleshooting tips.
-
-Runbook
-
-Create a brief runbook covering common failures (network down, Chromium crash).
-
-Future enhancements
-
-Auto-update mechanism via Balena Supervisor updates.
-
-Centralized logging or health-check dashboard.
-
-By following this structure—Setup → Familiarization → Configuration → Build → Validation → Documentation—you ensure a repeatable, maintainable kiosk deployment. Let me know if you’d like to dive deeper on any particular phase or need samples of Docker/start.sh modifications.
-
-
-
-
-
-
-
-
-You said:
-Can you write the readme for a repo that attempts to accomplish this
-
-
-ChatGPT said:
-markdown
-Copy
-Edit
-# balena-browser-kiosk
-
-A Balena-powered Chromium kiosk application for Raspberry Pi 400. On boot, the device will automatically launch Chromium in kiosk mode and navigate to `http://192.168.50.10`.
-
----
-
-## Table of Contents
-
-1. [Overview](#overview)  
-2. [Prerequisites](#prerequisites)  
-3. [Getting Started](#getting-started)  
-4. [Configuration](#configuration)  
-5. [Build & Deployment](#build--deployment)  
-6. [Validation & Troubleshooting](#validation--troubleshooting)  
-7. [Customization](#customization)  
-8. [Contributing](#contributing)  
-9. [License](#license)  
-
----
-
-## Overview
-
-This repository provides a Docker-based service that runs Chromium in kiosk mode on a Raspberry Pi 400. It leverages the [balena-io-experimental/browser](https://github.com/balena-io-experimental/browser) template, adapting it to:
-
-- Boot the Pi 400 from microSD with BalenaOS  
-- Launch Chromium in full-screen kiosk mode  
-- Navigate automatically to `http://192.168.50.10` on each boot  
-
----
-
-## Prerequisites
-
-- **Hardware**  
-  - Raspberry Pi 400 with official power supply  
-  - microSD card (≥ 16 GB, Class 10 recommended)  
-  - HDMI cable and HDMI-capable monitor  
-
-- **Software**  
-  - [Balena CLI](https://github.com/balena-io/balena-cli) (v13.0.0 or later)  
-  - A Balena Cloud account (free tier is sufficient)  
-  - Docker (for local builds)  
-
-- **Network**  
-  - A DHCP server that can assign or reserve the static IP `192.168.50.10`  
-  - Wired Ethernet or Wi-Fi network accessible by the Pi 400  
-
----
-
-## Getting Started
-
-1. **Clone the repository**  
    ```bash
-   git clone https://github.com/your-org/balena-browser-kiosk.git
-   cd balena-browser-kiosk
-Log in to Balena
+   balena build --device-type raspberrypi4-64 .
+   # or
+   balena push <appname>
+   ```
 
-bash
-Copy
-Edit
-balena login
-Create a Balena application (if not already existing)
+2. Optionally define the URL:
 
-bash
-Copy
-Edit
-balena app create browser-kiosk --type raspberrypi4-64
-Configuration
-Set the target URL
-By default, the container will navigate to http://192.168.50.10. To change this, you may:
+   ```bash
+   balena env add BROWSER_URL https://example.org --application <appname>
+   ```
 
-Edit the ENV BROWSER_URL in Dockerfile.template.
+After the container boots, Chromium opens in kiosk mode and navigates to the
+configured URL.
 
-Or set the device environment variable in Balena Cloud:
+## License
 
-bash
-Copy
-Edit
-balena env add BROWSER_URL http://192.168.50.10 --application browser-kiosk
-Adjust Chromium flags
-The launch script (start.sh) includes sensible defaults:
-
-bash
-Copy
-Edit
-chromium-browser \
-  --kiosk \
-  --no-first-run \
-  --disable-infobars \
-  --incognito \
-  "$BROWSER_URL"
-You may append or remove flags as needed.
-
-Static IP configuration
-If you require a fixed IP without DHCP reservation, you may modify /etc/dhcpcd.conf in the container or provision via Balena Network settings.
-
-Build & Deployment
-Local build (optional)
-
-bash
-Copy
-Edit
-balena local build --arch=arm64 .
-Push to Balena Cloud
-
-bash
-Copy
-Edit
-balena push browser-kiosk
-Provision the device
-
-Download the Balena-flashed image for your application from Balena Cloud.
-
-Flash your microSD card (e.g., with Balena Etcher).
-
-Insert into the Pi 400 and power on.
-
-Monitor logs
-
-bash
-Copy
-Edit
-balena logs <device-uuid> --follow
-Validation & Troubleshooting
-Chromium fails to launch
-
-Verify that start.sh has executable permissions.
-
-Check for missing dependencies in the Dockerfile.
-
-Tail the logs for errors: balena logs <device-uuid>.
-
-Page does not load
-
-Confirm network connectivity (ping 192.168.50.10).
-
-Ensure that BROWSER_URL is correct and reachable.
-
-Performance tuning
-
-Enable GPU acceleration flags: --use-gl=egl and --enable-features=VaapiVideoDecoder.
-
-Disable unneeded services to accelerate boot time.
-
-Auto-restart on crash
-
-A simple loop is included in start.sh to relaunch Chromium if it exits unexpectedly.
-
-Customization
-Feel free to extend this project:
-
-Auto-update mechanism via Balena Supervisor.
-
-Health-check endpoint to verify kiosk uptime.
-
-Centralized logging or integration with external dashboards.
-
-For advanced features, refer to the Balena documentation:
-Balena Documentation
-
-Contributing
-Fork the repository.
-
-Create a feature branch (git checkout -b feature/your-feature).
-
-Commit your changes (git commit -m "Add your feature").
-
-Push to the branch (git push origin feature/your-feature).
-
-Open a Pull Request.
-
-Please adhere to the existing code style and include tests for any significant changes.
-
-License
-This project is licensed under the MIT License.
+MIT

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+URL="${BROWSER_URL:-http://192.168.50.10}"
+
+cat <<EOT > ~/.xinitrc
+matchbox-window-manager -use_titlebar no -use_cursor no &
+chromium-browser \
+  --kiosk \
+  --no-first-run \
+  --disable-infobars \
+  --disable-session-crashed-bubble \
+  --disable-features=TranslateUI \
+  "$URL"
+EOT
+chmod +x ~/.xinitrc
+
+while true; do
+    xinit -- -nocursor
+    sleep 1
+done
+


### PR DESCRIPTION
## Summary
- set up Dockerfile.template for balena Chromium kiosk
- add looping start.sh script
- simplify README with usage instructions

## Testing
- `bash -n start.sh`

------
https://chatgpt.com/codex/tasks/task_b_68630af4d1f8832da2a6b64e5174b119